### PR TITLE
fix terminal-notifier command to work for osx-mavericks

### DIFF
--- a/src/Hot/Notify/Notify.php
+++ b/src/Hot/Notify/Notify.php
@@ -9,7 +9,7 @@ class Notify
         $x_message = $this->esc($message);
 
         if ($this->execute('which terminal-notifier')) {
-            $this->execute("terminal-notifier -title '{$x_title}' -message '{$x_message}'");
+            $this->execute("terminal-notifier -title '{$x_title}' -message '{$x_message}' -sender com.apple.Terminal");
         } else if ($this->execute('which notify-send')) {
             $this->execute("notify-send -t 2000 '{$x_title}' '$x_message'");
         } else {


### PR DESCRIPTION
Looks like terminal-notifier CLI commands don't work in Mavericks as expected.  Adding the -sender parameter fixes it.  
