### PR TITLE
Update hot-phpunit-runner

### DIFF
--- a/bin/hot-phpunit-runner
+++ b/bin/hot-phpunit-runner
@@ -1,5 +1,5 @@
 #!/usr/bin/env php
 <?php
 
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/../../../autoload.php';
 Hot\PHPUnit\Runner::handle();


### PR DESCRIPTION
set a relative path to the composer autoload file so this can be installed globally too.
