### PR TITLE
Fixing the runner on windows

### DIFF
--- a/src/Hot/PHPUnit/Request.php
+++ b/src/Hot/PHPUnit/Request.php
@@ -20,7 +20,10 @@ class Request extends Map
      */
     public function getBin()
     {
-        return $this->bin;
+	    if(strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+		    return PHP_BINARY . ' ' . $this->bin;
+	    else
+            return $this->bin;
     }
 
     public function getHash($names)


### PR DESCRIPTION
The runner throws lots of errors on windows since there is no /usr/bin/env this fixes that by calling the script with php directly